### PR TITLE
STAT-2560: Cleanup uavcan_send_debug_msg() implementation

### DIFF
--- a/modules/uavcan_debug/uavcan_debug.c
+++ b/modules/uavcan_debug/uavcan_debug.c
@@ -19,7 +19,7 @@ void uavcan_send_debug_msg(uint8_t debug_level, char* source, const char *fmt, .
     /* Memory stream object to be used as a string writer */
     msObjectInit(&ms, (uint8_t *)log_msg.text, sizeof(log_msg.text), 0);
 
-    /* Print into the log_msg.text. Don't use chsprintf(), because null-terminated
+    /* Print into the log_msg.text. Don't use chsnprintf(), because null-terminated
        strings will clip to 89 usable chars, instead of 90. By using chvprintf()
        with a MemoryStream, we are able to use all 90 characters of log_msg.text. */
     chp = (BaseSequentialStream *)(void *)&ms;

--- a/modules/uavcan_debug/uavcan_debug.c
+++ b/modules/uavcan_debug/uavcan_debug.c
@@ -14,16 +14,19 @@ void uavcan_send_debug_msg(uint8_t debug_level, char* source, const char *fmt, .
     va_list ap;
     MemoryStream ms;
     BaseSequentialStream *chp;
+    size_t printf_len;
 
-    /* Memory stream object to be used as a string writer, reserving one
-     byte for the final zero.*/
+    /* Memory stream object to be used as a string writer */
     msObjectInit(&ms, (uint8_t *)log_msg.text, sizeof(log_msg.text), 0);
 
-    /* Performing the print operation using the common code.*/
+    /* Print into the log_msg.text. Don't use chsprintf(), because null-terminated
+       strings will clip to 89 usable chars, instead of 90. By using chvprintf()
+       with a MemoryStream, we are able to use all 90 characters of log_msg.text. */
     chp = (BaseSequentialStream *)(void *)&ms;
     va_start(ap, fmt);
-    log_msg.text_len = MIN((size_t)chvprintf(chp, fmt, ap), sizeof(log_msg.text));
+    printf_len = (size_t)chvprintf(chp, fmt, ap);
     va_end(ap);
+    log_msg.text_len = MIN(printf_len, sizeof(log_msg.text));
 
     log_msg.source_len = strnlen(source, sizeof(log_msg.source));
     memcpy(log_msg.source, source, log_msg.source_len);


### PR DESCRIPTION
*The PR fulfills these requirements*:
[ ]  Documentation has been added / updated
[ ]  Design change has been reviewed
[ x ] Change or fix has been tested
[ ]  Change or fix is automatically tested or included in regression testing
[ x ]  Commit message adheres to company guidelines
[ n/a ]  Coding style adheres to company guidelines
[ x ]  Comments have been updated to reflect the latest design (esp file header)
[ x ]  Shared resources are protected (embedded / multi-threaded code)
[ x ]  Error handling (detection/propagation/reporting/etc) has been considered

*Brief summary of the change:*
- Add comments to explain why MemoryStream with chvprintf() is used, instead of chsprintf()
- Cleanup sloppy usage of MIN() macro, to avoid calling chvprintf() twice

*Link to Jira ticket (if applicable):*
https://matternet.atlassian.net/browse/STAT-2560

*Links to documentation:*

*Links to test plan and/or test cases:*
```
static char str_buf[]  = "abcdefghijklmnopqrstuvwxy";            // len = 25
static char str_buf2[] = "abcdefghijklmnopqrstuvwxy01234567890"; // len = 35

void init(void) {
    uavcan_send_debug_msg(UAVCAN_PROTOCOL_DEBUG_LOGLEVEL_INFO, str_buf2, "%s%s%s%s", str_buf, str_buf, str_buf, str_buf);
}
```
-->
```
125	14:52:42.079	INFO	abcdefghijklmnopqrstuvwxy012345	abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmno
```

*Does this PR introduce a breaking change? If yes, describe.*
No