### PR TITLE
Minor improvements to error handling in UAVCAN parameter get/set funcs

### DIFF
--- a/modules/param/param.c
+++ b/modules/param/param.c
@@ -101,6 +101,7 @@ void param_register(const struct param_descriptor_header_s* param_descriptor_hea
         for (uint32_t i=0; i<new_param_idx; i++) {
             if(!memcmp(&param_keys[i], &param_keys[new_param_idx], sizeof(struct param_key_s))) {
                 // Double registration or hash collision
+                param_release();
                 return;
             }
         }
@@ -152,6 +153,8 @@ enum param_type_t param_get_type_by_index(uint16_t param_idx) {
     return descriptor->type;
 }
 
+// Return the index of named parameter.
+// If parameter name is invalid or does not exist, returns -1.
 int16_t param_get_index_by_name(uint8_t name_len, char* name) {
     if (name_len > 92) {
         return -1;

--- a/modules/uavcan_param_interface/uavcan_param_interface.c
+++ b/modules/uavcan_param_interface/uavcan_param_interface.c
@@ -38,6 +38,7 @@ static void getset_req_handler(size_t msg_size, const void* buf, void* ctx) {
 
     struct uavcan_protocol_param_GetSet_res_s res;
     memset(&res, 0, sizeof(struct uavcan_protocol_param_GetSet_res_s));
+    // NOTE: ^^^ Among other things, this will set res.name_len to 0, indicating "no such parameter" by default.
 
     param_acquire();
 
@@ -74,10 +75,7 @@ static void getset_req_handler(size_t msg_size, const void* buf, void* ctx) {
         }
 
         const char* param_name = param_get_name_by_index(param_idx);
-        if (param_name == NULL) {
-            // This shouldn't be possible, but let's be defensive
-            res.name_len = 0;
-        } else {
+        if (param_name != NULL) {  // NULL shouldn't be possible, but let's be defensive
             res.name_len = strnlen(param_name,92);
             memcpy(res.name, param_name, res.name_len);
         }

--- a/modules/uavcan_param_interface/uavcan_param_interface.c
+++ b/modules/uavcan_param_interface/uavcan_param_interface.c
@@ -41,13 +41,13 @@ static void getset_req_handler(size_t msg_size, const void* buf, void* ctx) {
 
     param_acquire();
 
-    int16_t param_idx = req->index;
+    int16_t param_idx = (int16_t)req->index;   // uavcan.protocol.param.GetSet: uint13 index
     if (req->name_len > 0) {
         // If the name field is not empty, we are to prefer it over the param index field
         param_idx = param_get_index_by_name(req->name_len, (char*)req->name);
     }
 
-    if (param_get_exists(param_idx)) {
+    if ((param_idx >= 0) && param_get_exists(param_idx)) {
         switch(req->value.uavcan_protocol_param_Value_type) {
             case UAVCAN_PROTOCOL_PARAM_VALUE_TYPE_INTEGER_VALUE: {
                 // set request: int64
@@ -74,8 +74,13 @@ static void getset_req_handler(size_t msg_size, const void* buf, void* ctx) {
         }
 
         const char* param_name = param_get_name_by_index(param_idx);
-        res.name_len = strnlen(param_name,92);
-        memcpy(res.name, param_name, res.name_len);
+        if (param_name == NULL) {
+            // This shouldn't be possible, but let's be defensive
+            res.name_len = 0;
+        } else {
+            res.name_len = strnlen(param_name,92);
+            memcpy(res.name, param_name, res.name_len);
+        }
 
         switch(param_get_type_by_index(param_idx)) {
             case PARAM_TYPE_STRING:


### PR DESCRIPTION
- Make sure to release param mutex for early return in modules/param/param.c::param_register()
- More careful handling of signed vs unsigned type for param_idx values
- Check and gracefully handle when param_get_name_by_index() returns NULL
- NOTE: This work is after some code inspection related to tickets such as:
   * STAT-2600 - UAVCAN Boards Drop Off CAN Bus
   * STAT-2691 - Stat 2 in error with missing Hangar board, after weekend
- NOTE: I doubt that these changes will solve any problems, but they shouldn't hurt

- Tested lightly on Station 3:
  * Start/stop mttr-flash a few times
  * Open/close hangar with pre-close disabled