### PR TITLE
AVX-89 add platform for stm32f302xb (part 2)

### DIFF
--- a/modules/platform_stm32f302xb/platform_stm32f302xb.h
+++ b/modules/platform_stm32f302xb/platform_stm32f302xb.h
@@ -2,7 +2,8 @@
 
 #include <stdint.h>
 
-#define STM32F302xB
+// NOTE: in the CMSIS (stm32f3xx.h), this is #define used for the STM32F302xB
+#define STM32F302xC
 
 #define BOARD_PARAM1_FLASH_SIZE ((size_t)&_param1_flash_sec_end - (size_t)&_param1_flash_sec)
 #define BOARD_PARAM2_FLASH_SIZE ((size_t)&_param2_flash_sec_end - (size_t)&_param2_flash_sec)


### PR DESCRIPTION
This is a bug fix for the previous [PR#6](https://github.com/matternet/framework/pull/6) to properly add the STM32F302xB MCU