### PR TITLE
STAT-2911: unit test flags, various improvements to temp libs

### DIFF
--- a/modules/ds18b20/ds18b20.c
+++ b/modules/ds18b20/ds18b20.c
@@ -43,7 +43,7 @@ DS18B20_Status DS18B20_Start(OneWire_t* OneWire, uint8_t *ROM) {
     /* Reset line */
     if (OneWire_Reset(OneWire) == ONEWIRE_FAILURE) return DS18B20_FAILURE;
     /* Select ROM number */
-    OneWire_SelectWithPointer(OneWire, ROM);
+    OneWire_Select(OneWire, ROM);
     /* Start temperature conversion */
     OneWire_WriteByte(OneWire, DS18B20_CMD_CONVERTTEMP);
     
@@ -89,7 +89,7 @@ DS18B20_Status DS18B20_Read(OneWire_t* OneWire, uint8_t *ROM, float *destination
     /* Reset line */
     if (OneWire_Reset(OneWire) == ONEWIRE_FAILURE) return DS18B20_FAILURE;
     /* Select ROM number */
-    OneWire_SelectWithPointer(OneWire, ROM);
+    OneWire_Select(OneWire, ROM);
     /* Read scratchpad command by onewire protocol */
     OneWire_WriteByte(OneWire, ONEWIRE_CMD_RSCRATCHPAD);
     
@@ -187,7 +187,7 @@ DS18B20_Status DS18B20_GetResolution(OneWire_t* OneWire, uint8_t *ROM, DS18B20_R
     /* Reset line */
     if (OneWire_Reset(OneWire) == ONEWIRE_FAILURE) return DS18B20_FAILURE;
     /* Select ROM number */
-    OneWire_SelectWithPointer(OneWire, ROM);
+    OneWire_Select(OneWire, ROM);
     /* Read scratchpad command by onewire protocol */
     OneWire_WriteByte(OneWire, ONEWIRE_CMD_RSCRATCHPAD);
     
@@ -216,7 +216,7 @@ DS18B20_Status DS18B20_SetResolution(OneWire_t* OneWire, uint8_t *ROM, DS18B20_R
     /* Reset line */
     if (OneWire_Reset(OneWire) == ONEWIRE_FAILURE) return DS18B20_FAILURE;
     /* Select ROM number */
-    OneWire_SelectWithPointer(OneWire, ROM);
+    OneWire_Select(OneWire, ROM);
     /* Read scratchpad command by onewire protocol */
     OneWire_WriteByte(OneWire, ONEWIRE_CMD_RSCRATCHPAD);
     
@@ -268,7 +268,7 @@ DS18B20_Status DS18B20_SetResolution(OneWire_t* OneWire, uint8_t *ROM, DS18B20_R
     /* Reset line */
     if (OneWire_Reset(OneWire) == ONEWIRE_FAILURE) return DS18B20_FAILURE;
     /* Select ROM number */
-    OneWire_SelectWithPointer(OneWire, ROM);
+    OneWire_Select(OneWire, ROM);
     /* Write scratchpad command by onewire protocol, only trigger_register_hi, trigger_register_lo and conf_register register can be written */
     OneWire_WriteByte(OneWire, ONEWIRE_CMD_WSCRATCHPAD);
     
@@ -280,7 +280,7 @@ DS18B20_Status DS18B20_SetResolution(OneWire_t* OneWire, uint8_t *ROM, DS18B20_R
     /* Reset line */
     OneWire_Reset(OneWire);
     /* Select ROM number */
-    OneWire_SelectWithPointer(OneWire, ROM);
+    OneWire_Select(OneWire, ROM);
     /* Copy scratchpad to EEPROM of DS18B20 */
     OneWire_WriteByte(OneWire, ONEWIRE_CMD_CPYSCRATCHPAD);
     
@@ -312,7 +312,7 @@ DS18B20_Status DS18B20_SetAlarmLowTemperature(OneWire_t* OneWire, uint8_t *ROM, 
     /* Reset line */
     if (OneWire_Reset(OneWire) == ONEWIRE_FAILURE) return DS18B20_FAILURE;
     /* Select ROM number */
-    OneWire_SelectWithPointer(OneWire, ROM);
+    OneWire_Select(OneWire, ROM);
     /* Read scratchpad command by onewire protocol */
     OneWire_WriteByte(OneWire, ONEWIRE_CMD_RSCRATCHPAD);
     
@@ -329,7 +329,7 @@ DS18B20_Status DS18B20_SetAlarmLowTemperature(OneWire_t* OneWire, uint8_t *ROM, 
     /* Reset line */
     if (OneWire_Reset(OneWire) == ONEWIRE_FAILURE) return DS18B20_FAILURE;
     /* Select ROM number */
-    OneWire_SelectWithPointer(OneWire, ROM);
+    OneWire_Select(OneWire, ROM);
     /* Write scratchpad command by onewire protocol, only trigger_register_hi, trigger_register_lo and conf_register register can be written */
     OneWire_WriteByte(OneWire, ONEWIRE_CMD_WSCRATCHPAD);
     
@@ -341,7 +341,7 @@ DS18B20_Status DS18B20_SetAlarmLowTemperature(OneWire_t* OneWire, uint8_t *ROM, 
     /* Reset line */
     if (OneWire_Reset(OneWire) == ONEWIRE_FAILURE) return DS18B20_FAILURE;
     /* Select ROM number */
-    OneWire_SelectWithPointer(OneWire, ROM);
+    OneWire_Select(OneWire, ROM);
     /* Copy scratchpad to EEPROM of DS18B20 */
     OneWire_WriteByte(OneWire, ONEWIRE_CMD_CPYSCRATCHPAD);
     
@@ -363,7 +363,7 @@ DS18B20_Status DS18B20_SetAlarmHighTemperature(OneWire_t* OneWire, uint8_t *ROM,
     /* Reset line */
     if (OneWire_Reset(OneWire) == ONEWIRE_FAILURE) return DS18B20_FAILURE;
     /* Select ROM number */
-    OneWire_SelectWithPointer(OneWire, ROM);
+    OneWire_Select(OneWire, ROM);
     /* Read scratchpad command by onewire protocol */
     OneWire_WriteByte(OneWire, ONEWIRE_CMD_RSCRATCHPAD);
     
@@ -380,7 +380,7 @@ DS18B20_Status DS18B20_SetAlarmHighTemperature(OneWire_t* OneWire, uint8_t *ROM,
     /* Reset line */
     if (OneWire_Reset(OneWire) == ONEWIRE_FAILURE) return DS18B20_FAILURE;
     /* Select ROM number */
-    OneWire_SelectWithPointer(OneWire, ROM);
+    OneWire_Select(OneWire, ROM);
     /* Write scratchpad command by onewire protocol, only trigger_register_hi, trigger_register_lo and conf_register register can be written */
     OneWire_WriteByte(OneWire, ONEWIRE_CMD_WSCRATCHPAD);
     
@@ -392,7 +392,7 @@ DS18B20_Status DS18B20_SetAlarmHighTemperature(OneWire_t* OneWire, uint8_t *ROM,
     /* Reset line */
     if (OneWire_Reset(OneWire) == ONEWIRE_FAILURE) return DS18B20_FAILURE;
     /* Select ROM number */
-    OneWire_SelectWithPointer(OneWire, ROM);
+    OneWire_Select(OneWire, ROM);
     /* Copy scratchpad to EEPROM of DS18B20 */
     OneWire_WriteByte(OneWire, ONEWIRE_CMD_CPYSCRATCHPAD);
     
@@ -408,7 +408,7 @@ DS18B20_Status DS18B20_DisableAlarmTemperature(OneWire_t* OneWire, uint8_t *ROM)
     /* Reset line */
     if (OneWire_Reset(OneWire) == ONEWIRE_FAILURE) return DS18B20_FAILURE;
     /* Select ROM number */
-    OneWire_SelectWithPointer(OneWire, ROM);
+    OneWire_Select(OneWire, ROM);
     /* Read scratchpad command by onewire protocol */
     OneWire_WriteByte(OneWire, ONEWIRE_CMD_RSCRATCHPAD);
     
@@ -426,7 +426,7 @@ DS18B20_Status DS18B20_DisableAlarmTemperature(OneWire_t* OneWire, uint8_t *ROM)
     /* Reset line */
     if (OneWire_Reset(OneWire) == ONEWIRE_FAILURE) return DS18B20_FAILURE;
     /* Select ROM number */
-    OneWire_SelectWithPointer(OneWire, ROM);
+    OneWire_Select(OneWire, ROM);
     /* Write scratchpad command by onewire protocol, only trigger_register_hi, trigger_register_lo and conf_register register can be written */
     OneWire_WriteByte(OneWire, ONEWIRE_CMD_WSCRATCHPAD);
     
@@ -438,7 +438,7 @@ DS18B20_Status DS18B20_DisableAlarmTemperature(OneWire_t* OneWire, uint8_t *ROM)
     /* Reset line */
     if (OneWire_Reset(OneWire) == ONEWIRE_FAILURE) return DS18B20_FAILURE;
     /* Select ROM number */
-    OneWire_SelectWithPointer(OneWire, ROM);
+    OneWire_Select(OneWire, ROM);
     /* Copy scratchpad to EEPROM of DS18B20 */
     OneWire_WriteByte(OneWire, ONEWIRE_CMD_CPYSCRATCHPAD);
     

--- a/modules/ds18b20/ds18b20.c
+++ b/modules/ds18b20/ds18b20.c
@@ -26,6 +26,7 @@
 
 #include "ds18b20.h"
 #include <stdbool.h>
+
 /**
  * @brief  Private function converts config register value to uint8_t resolution
  * @param  config_register: value of configuration register.
@@ -453,12 +454,13 @@ DS18B20_Status DS18B20_AlarmSearch(OneWire_t* OneWire) {
 
 DS18B20_Status DS18B20_AllDone(OneWire_t* OneWire) {
     if (!OneWire) return DS18B20_USAGE_ERROR;
+    uint8_t line = 0;
+    OneWire_ReadBit(OneWire, &line);
     /* If read bit is low, then device is not finished yet with calculation temperature */
-    uint8_t is_conversion_done = 0;
-    if (OneWire_ReadBit(OneWire, &is_conversion_done)){
+    if (line == 1){
         return DS18B20_SUCCESS;
     }
-    return DS18B20_FAILURE;
+    return DS18B20_CONVERSION_IN_PROGRESS;
 }
 
 

--- a/modules/ds18b20/ds18b20.h
+++ b/modules/ds18b20/ds18b20.h
@@ -68,7 +68,11 @@
 \endverbatim
  */
 
+#ifdef UNIT_TEST
+#include "onewire.h"
+#else
 #include <modules/onewire/onewire.h>
+#endif // UNIT_TEST
 
 /**
  * @defgroup DS18B20_Macros

--- a/modules/ds18b20/ds18b20.h
+++ b/modules/ds18b20/ds18b20.h
@@ -193,6 +193,7 @@ DS18B20_Status DS18B20_Read(OneWire_t* OneWireStruct, uint8_t* ROM, float* desti
  * @param  *OneWireStruct: Pointer to @ref OneWire_t working structure (OneWire channel)
  * @param  *ROM: Pointer to first byte of ROM address for desired DS12B80 device.
  *         Entire ROM address is 8-bytes long
+ * @param  resolution: DS18B20_Resolution_t type describing its resolution
  * @return retval: see defintion of DS18B20_Status
  */
 DS18B20_Status DS18B20_GetResolution(OneWire_t* OneWireStruct, uint8_t* ROM, DS18B20_Resolution_t* resolution);

--- a/modules/ds18b20/ds18b20.h
+++ b/modules/ds18b20/ds18b20.h
@@ -144,11 +144,11 @@ typedef enum {
  * @brief  DS18B0 Return Codes
  */
 typedef enum {
-    DS18B20_USAGE_ERROR            = -5,  /*!< Function Usage Error, check parameters */
-    DS18B20_INVALID_DEVICE         = -4,  /*!< Device does not match DS18B20 Family Code */
+    DS18B20_USAGE_ERROR            = -4,  /*!< Function Usage Error, check parameters */
+    DS18B20_INVALID_DEVICE         = -3,  /*!< Device does not match DS18B20 Family Code */
+    DS18B20_CONVERSION_IN_PROGRESS = -2,  /*!< Sensor still processing information, line is low */
     DS18B20_FAILURE                = -1,  /*!< General operation failure, CRC Invalid */
     DS18B20_SUCCESS                =  0,  /*!< DS18B20 function successful */
-    DS18B20_CONVERSION_IN_PROGRESS =  1,  /*!< Sensor still processing information, line is low */
 } DS18B20_Status;
 
 /**

--- a/modules/onewire/onewire.c
+++ b/modules/onewire/onewire.c
@@ -17,9 +17,15 @@
  * |----------------------------------------------------------------------
  */
 
+#ifdef UNIT_TEST
+#include "timing.h"
+#include <stdio.h>
+#else
+#include <modules/timing/timing.h>
+#endif // UNIT_TEST
+
 /* includes to access HAL/PAL calls, need to access directly since abstraction for ChibiOS in framework is lackluster */
-#include <hal.h>                   // all encompasing hal.h include. includes everything related to hal that you would need.
-#include <modules/timing/timing.h> // need timing module for microsecond level bit-banging
+#include <hal.h>
 #include "onewire.h"
 
 // ONEWIRE ABSTRACTION HELPERS
@@ -261,7 +267,6 @@ OneWireStatus OneWire_Search(OneWire_t* OneWireStruct, uint8_t command) {
             }
         /* Loop until through all ROM bytes 0-7 */
         } while (rom_byte_number < ROM_DATA_SIZE_BYTES);
-
         /* If the search was successful then */
         if (!(id_bit_number <= ROM_DATA_SIZE_BITS)) {
             /* Search successful so set LastDiscrepancy, LastDeviceFlag, search_result */
@@ -385,15 +390,6 @@ OneWireStatus OneWire_Select(OneWire_t* OneWireStruct, uint8_t* addr) {
     return ONEWIRE_SUCCESS;
 }
 
-OneWireStatus OneWire_SelectWithPointer(OneWire_t* OneWireStruct, uint8_t* ROM) {
-    if (!OneWireStruct || !ROM) return ONEWIRE_FAILURE;
-    OneWire_WriteByte(OneWireStruct, ONEWIRE_CMD_MATCHROM);
-    for (uint8_t i = 0; i < ROM_DATA_SIZE_BYTES; i++) {
-        OneWire_WriteByte(OneWireStruct, ROM[i]);
-    }   
-    return ONEWIRE_SUCCESS;
-}
-
 OneWireStatus OneWire_CalculateCRC8(uint8_t *addr, uint8_t len, uint8_t* rslt) {
     if (!addr) return ONEWIRE_FAILURE;
 
@@ -416,6 +412,8 @@ OneWireStatus OneWire_CalculateCRC8(uint8_t *addr, uint8_t len, uint8_t* rslt) {
 }
 
 uint8_t OneWire_LookupCRC8(uint8_t *data, uint8_t len) {
+    if (!data) return ONEWIRE_FAILURE;
+
     static uint8_t crc88540_table[256] = {
         0x0, 0x5e, 0xbc, 0xe2, 0x61, 0x3f, 0xdd, 0x83, 0xc2, 0x9c, 0x7e, 0x20, 0xa3, 0xfd, 0x1f, 0x41, 
         0x9d, 0xc3, 0x21, 0x7f, 0xfc, 0xa2, 0x40, 0x1e, 0x5f, 0x1, 0xe3, 0xbd, 0x3e, 0x60, 0x82, 0xdc, 
@@ -434,6 +432,7 @@ uint8_t OneWire_LookupCRC8(uint8_t *data, uint8_t len) {
         0xe9, 0xb7, 0x55, 0xb, 0x88, 0xd6, 0x34, 0x6a, 0x2b, 0x75, 0x97, 0xc9, 0x4a, 0x14, 0xf6, 0xa8, 
         0x74, 0x2a, 0xc8, 0x96, 0x15, 0x4b, 0xa9, 0xf7, 0xb6, 0xe8, 0xa, 0x54, 0xd7, 0x89, 0x6b, 0x35,
     };
+
     uint8_t result = 0; 
     while(len--) {
         result = crc88540_table[result ^ *data++];

--- a/modules/onewire/onewire.c
+++ b/modules/onewire/onewire.c
@@ -19,7 +19,6 @@
 
 #ifdef UNIT_TEST
 #include "timing.h"
-#include <stdio.h>
 #else
 #include <modules/timing/timing.h>
 #endif // UNIT_TEST

--- a/modules/onewire/onewire.h
+++ b/modules/onewire/onewire.h
@@ -76,7 +76,7 @@ typedef enum {
  * @note   There are three advanced search variations using the same state information, namely LastDiscrepancy, LastFamilyDiscrepancy, LastDeviceFlag, and ROM_NO.
  * @note   These variations allow specific family types to be targeted or skipped and device present verification 
  * @note   See https://www.maximintegrated.com/en/design/technical-documents/app-notes/1/187.html for more info.
- * @note   All members except ROM_NUM member is fully private and should not be touched by user.
+ * @note   All members except ROM_NUM member are fully private and should not be touched by user.
 
  */
 typedef struct {

--- a/modules/onewire/onewire.h
+++ b/modules/onewire/onewire.h
@@ -57,8 +57,8 @@ extern "C" {
 
 /* General OneWire return codes */
 typedef enum {
-    ONEWIRE_FAILURE          =  0, // Error: Usage / Operation Failure.
-    ONEWIRE_SUCCESS          =  1  // Operation Successful
+    ONEWIRE_FAILURE          =  -1, // Error: Usage / Operation Failure.
+    ONEWIRE_SUCCESS          =   0  // Operation Successful
 } OneWireStatus;
 
 /**

--- a/modules/onewire/onewire.h
+++ b/modules/onewire/onewire.h
@@ -17,8 +17,6 @@
  * |----------------------------------------------------------------------
  */
 
-
-
 #ifndef ONEWIRE_H
 #define ONEWIRE_H
 
@@ -75,7 +73,11 @@ typedef enum {
 
 /**
  * @brief  OneWire working struct
- * @note   Except ROM_NUM member, everything is fully private and should not be touched by user
+ * @note   There are three advanced search variations using the same state information, namely LastDiscrepancy, LastFamilyDiscrepancy, LastDeviceFlag, and ROM_NO.
+ * @note   These variations allow specific family types to be targeted or skipped and device present verification 
+ * @note   See https://www.maximintegrated.com/en/design/technical-documents/app-notes/1/187.html for more info.
+ * @note   All members except ROM_NUM member is fully private and should not be touched by user.
+
  */
 typedef struct {
     uint32_t PalLine;                        /*!< GPIO port to be used for I/O functions */
@@ -95,7 +97,6 @@ typedef struct {
  * @{
  */
 
-/* OneWire delay */
 /**
  * @brief  Sleep for time_us microseconds
  * @note   Blocking sleep function. Seems to be faster/more accurate than chThdSleepMicroseconds()
@@ -257,14 +258,6 @@ OneWireStatus OneWire_GetFullROM(OneWire_t* OneWireStruct, uint8_t *firstIndex);
 OneWireStatus OneWire_Select(OneWire_t* OneWireStruct, uint8_t* addr);
 
 /**
- * @brief  Selects specific slave on bus with pointer address
- * @param  *OneWireStruct: Pointer to an initialized @ref Onewire_t structure
- * @param  *ROM: Pointer to first byte of ROM address
- * @return retval: see defintion of OneWireStatus
- */
-OneWireStatus OneWire_SelectWithPointer(OneWire_t* OneWireStruct, uint8_t* ROM);
-
-/**
  * @brief  Calculates 8-bit CRC for 1-wire devices. 
  * @note   CRC = X^8 + X^5 + X^4 + 1
  * @param  *addr:  Pointer to 8-bit array of data to calculate CRC
@@ -282,6 +275,29 @@ OneWireStatus OneWire_CalculateCRC8(uint8_t* addr, uint8_t len, uint8_t* rslt);
  * @return retval: 8-bit CRC value for given array
  */
 uint8_t OneWire_LookupCRC8(uint8_t* addr, uint8_t len);
+
+/* Advanced Search Variations */
+
+/**
+ * @brief  Preset the search state to first find a particular family type
+ * @param  *ROM: Pointer to first byte of ROM address
+ * @return retval: see definition of OneWireStatus
+ */
+OneWireStatus OneWire_TargetSetup(OneWire_t* OneWireStruct, uint8_t family_code);
+
+/**
+ * @brief  Verify if a device with a known ROM is connected to onewire
+ * @param  *OneWireStruct: Pointer to an initialized @ref Onewire_t structure
+ * @return retval: see defintion of OneWireStatus
+ */
+OneWireStatus OneWire_Verify(OneWire_t* OneWireStruct);
+
+/**
+ * @brief  Sets the search state to skip all of the devices that have the family code that was found in the previous search.
+ * @param  *OneWireStruct: Pointer to an initialized @ref Onewire_t structure
+ * @return retval: see defintion of OneWireStatus
+ */
+OneWireStatus OneWire_FamilySkipSetup(OneWire_t* OneWireStruct);
 
 /* C++ detection */
 #ifdef __cplusplus

--- a/modules/onewire/onewire.h
+++ b/modules/onewire/onewire.h
@@ -272,7 +272,7 @@ OneWireStatus OneWire_CalculateCRC8(uint8_t* addr, uint8_t len, uint8_t* rslt);
  * @note   CRC = X^8 + X^5 + X^4 + 1
  * @param  *addr:  Pointer to 8-bit array of data to calculate CRC
  * @param  len:    Number of bytes to check
- * @return retval: 8-bit CRC value for given array
+ * @return retval: 8-bit CRC value for given array, or ONEWIRE_FAILURE on usage error
  */
 uint8_t OneWire_LookupCRC8(uint8_t* addr, uint8_t len);
 


### PR DESCRIPTION

    - add unit test flags for ds18b20 and onewire modules
    - remove / rename onewire_select
    - add onewire advanced search options to onewire.h
    - documentation improvements

