### PR TITLE
AS-836 update for python3

### DIFF
--- a/modules/app_descriptor/crc_binary.py
+++ b/modules/app_descriptor/crc_binary.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import crcmod.predefined
 import sys
 import os
@@ -5,7 +7,7 @@ import binascii
 import struct
 
 app_descriptor_fmt = "<8cQI"
-SHARED_APP_DESCRIPTOR_SIGNATURES = ["\xd7\xe4\xf7\xba\xd0\x0f\x9b\xee", "\x40\xa2\xe4\xf1\x64\x68\x91\x06"]
+SHARED_APP_DESCRIPTOR_SIGNATURES = [b"\xd7\xe4\xf7\xba\xd0\x0f\x9b\xee", b"\x40\xa2\xe4\xf1\x64\x68\x91\x06"]
 
 crc64 = crcmod.predefined.Crc('crc-64-we')
 

--- a/modules/app_descriptor/module.mk
+++ b/modules/app_descriptor/module.mk
@@ -1,6 +1,8 @@
 APP_DESCRIPTOR_MODULE_DIR := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 
+PYTHON := python3
+
 .PHONY: INSERT_CRC
 POST_MAKE_ALL_RULE_HOOK: $(BUILDDIR)/$(PROJECT)-crc.bin
 $(BUILDDIR)/$(PROJECT)-crc.bin: $(BUILDDIR)/$(PROJECT).bin
-	python $(APP_DESCRIPTOR_MODULE_DIR)/crc_binary.py $< $@
+	$(PYTHON) $(APP_DESCRIPTOR_MODULE_DIR)/crc_binary.py $< $@

--- a/modules/uavcan/canard_dsdlc/canard_dsdlc.py
+++ b/modules/uavcan/canard_dsdlc/canard_dsdlc.py
@@ -1,4 +1,6 @@
-import uavcan.dsdl
+#!/usr/bin/env python3
+
+import pyuavcan_v0 as uavcan
 import argparse
 import os
 import em
@@ -44,11 +46,11 @@ for msg in messages:
     message_dict[msg.full_name] = msg
 
 for template in templates:
-    with open(os.path.join(templates_dir, template['source_file']), 'rb') as f:
+    with open(os.path.join(templates_dir, template['source_file']), 'rt') as f:
         template['source'] = f.read()
 
 def build_message(msg_name):
-    print 'building %s' % (msg_name,)
+    print('building %s' % (msg_name,))
     msg = message_dict[msg_name]
     for template in templates:
         output = em.expand(template['source'], msg=msg)
@@ -58,7 +60,7 @@ def build_message(msg_name):
 
         output_file = os.path.join(build_dir, em.expand('@{from canard_dsdlc_helpers import *}'+template['output_file'], msg=msg))
         mkdir_p(os.path.dirname(output_file))
-        with open(output_file, 'wb') as f:
+        with open(output_file, 'wt') as f:
             f.write(output)
 
 if __name__ == '__main__':
@@ -87,7 +89,7 @@ if __name__ == '__main__':
             pool.apply_async(build_message, (msg_name,))
     else:
         for msg_name in [msg.full_name for msg in messages]:
-            print 'building %s' % (msg_name,)
+            print('building %s' % (msg_name,))
             builtlist.add(msg_name)
             pool.apply_async(build_message, (msg_name,))
 

--- a/modules/uavcan/canard_dsdlc/canard_dsdlc.py
+++ b/modules/uavcan/canard_dsdlc/canard_dsdlc.py
@@ -3,7 +3,7 @@
 import pyuavcan_v0 as uavcan
 import argparse
 import os
-import em
+import em   # NOTE: must use empy v3.3.4
 from canard_dsdlc_helpers import *
 
 templates = [

--- a/modules/uavcan/canard_dsdlc/canard_dsdlc_helpers.py
+++ b/modules/uavcan/canard_dsdlc/canard_dsdlc_helpers.py
@@ -3,7 +3,7 @@
 import os
 import pyuavcan_v0 as uavcan
 import errno
-import em
+import em   # NOTE: must use empy v3.3.4
 import math
 import copy
 

--- a/modules/uavcan/canard_dsdlc/canard_dsdlc_helpers.py
+++ b/modules/uavcan/canard_dsdlc/canard_dsdlc_helpers.py
@@ -1,5 +1,7 @@
+#!/usr/bin/env python3
+
 import os
-import uavcan
+import pyuavcan_v0 as uavcan
 import errno
 import em
 import math

--- a/modules/uavcan/module.mk
+++ b/modules/uavcan/module.mk
@@ -1,5 +1,7 @@
 UAVCAN_MODULE_DIR := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 
+PYTHON := python3
+
 CSRC += $(UAVCAN_MODULE_DIR)/libcanard/canard.c
 
 UDEFS += -D"CANARD_ASSERT(x)"="{}"
@@ -12,7 +14,7 @@ INCDIR += $(BUILDDIR)/dsdlc/include
 
 $(BUILDDIR)/dsdlc.mk: $(foreach dsdl_dir,$(wildcard $(DSDL_NAMESPACE_DIRS)),$(shell find $(dsdl_dir)))
 	rm -rf $(BUILDDIR)/dsdlc
-	python $(UAVCAN_MODULE_DIR)/canard_dsdlc/canard_dsdlc.py $(addprefix --build=,$(MESSAGES_ENABLED)) $(DSDL_NAMESPACE_DIRS) $(BUILDDIR)/dsdlc
+	$(PYTHON) $(UAVCAN_MODULE_DIR)/canard_dsdlc/canard_dsdlc.py $(addprefix --build=,$(MESSAGES_ENABLED)) $(DSDL_NAMESPACE_DIRS) $(BUILDDIR)/dsdlc
 	find $(BUILDDIR)/dsdlc/src -name "*.c" | xargs echo CSRC += > $(BUILDDIR)/dsdlc.mk
 
 ifneq ($(MAKECMDGOALS),clean)


### PR DESCRIPTION
update compile process from python2 to python3

NOTE: these python scripts use empy v3.3.4.  As of this PR, current empy version is v4.2